### PR TITLE
fix: 修复 PanoMeasurePlugin 仅初始化 UI 面板仍占位为题。

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/icons-material": "^5.4.2",
     "@mui/material": "^5.4.2",
-    "@realsee/dnalogel": "2.0.0-alpha.20",
+    "@realsee/dnalogel": "2.0.0-alpha.21",
     "@realsee/five": "^5.0.0-alpha.123",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.41",
     "@types/offscreencanvas": "^2019.6.4",

--- a/examples/src/PanoMeasurePlugin/PanoMeasurePluginUsage.tsx
+++ b/examples/src/PanoMeasurePlugin/PanoMeasurePluginUsage.tsx
@@ -10,7 +10,7 @@ interface PanoRulerPluginUsePropTypes {
 const PanoMeasurePluginUsage = (props: PanoRulerPluginUsePropTypes) => {
     const five = unsafe__useFiveInstance()
     const panoMeasurePlugin = five.plugins.panoMeasurePlugin as ReturnType<typeof PanoMeasurePlugin>
-    const [measureEnableBtn, setMeasureEnableBtn] = React.useState<boolean>(false)
+    const [measureEnableBtn, setMeasureEnableBtn] = React.useState<boolean>(true)
 
     const handlePanoMeasurePluginListener = () => {
         panoMeasurePlugin.hook.on("modeChange", (mode) => {

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.0.0-alpha.21
+- 1.fix: 修复 PanoMeasurePlugin 仅初始化 UI 面板仍占位为题。
+
 ## 2.0.0-alpha.20
 - 1.fix: 修复 PanoMeasurePlugin hide 时 UI 面板仍占位为题。
 

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/realsee-developer/dnalogel.git",
   "description": "如视 VR 看房插件合集",
   "private": false,
-  "version": "2.0.0-alpha.20",
+  "version": "2.0.0-alpha.21",
   "license": "SEE LICENSE IN TERMS.txt",
   "scripts": {
     "build": "yarn run tsb && yarn run build:rollup && yarn build:docs",

--- a/plugins/src/PanoMeasurePlugin/Modules/UIController/style.ts
+++ b/plugins/src/PanoMeasurePlugin/Modules/UIController/style.ts
@@ -8,6 +8,7 @@ export const exitImage = '//vrlab-static.ljcdn.com/release/web/measure/exit.6693
 export const revokeImage = '//vrlab-static.ljcdn.com/release/web/measure/revoke.3e424843.png'
 
 export const uiWrapperStyle: Partial<CSSStyleDeclaration> = {
+  display: 'none',
   position: 'absolute',
   top: '0',
   left: '0',


### PR DESCRIPTION
fix: 修复 PanoMeasurePlugin 仅初始化 UI 面板仍占位为题。