### PR TITLE
fix(floorplan): 修复户型图房间材质 SVG 在某些情况下的定位问题

### DIFF
--- a/plugins/src/floorplan/Components/RoomMaterials/RoomMaterial.svelte
+++ b/plugins/src/floorplan/Components/RoomMaterials/RoomMaterial.svelte
@@ -31,8 +31,17 @@
 </div>
 
 <style>
+  .floorplan-plugin__room-material {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+  }
   svg {
     position: absolute;
+    left: 0;
+    top: 0;
     width: 100%;
     height: 100%;
     overflow: visible;


### PR DESCRIPTION
fix(floorplan): 户型图显式定义text-align,防止继承用户在更高级设置的属性