### PR TITLE
fix: PanoRulerPlugin 修改标尺隐藏策略，线长小于0.3m隐藏

### DIFF
--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.0.0-alpha.31
+- 1.fix: PanoRulerPlugin 修改标尺隐藏策略，线长小于0.3m隐藏
+
 ## 2.0.0-alpha.30
 - 1.feat: PanoMeasurePlugin 新增移动端UI交互模式
 - 2.feat: PanoMeasurePlugin 点线、标签气泡、删除按钮、三维坐标系UI交互优化

--- a/plugins/src/PanoRulerPlugin/Plugin.ts
+++ b/plugins/src/PanoRulerPlugin/Plugin.ts
@@ -442,7 +442,7 @@ export const PanoRulerPlugin: FivePlugin<PanoRulerPluginParameterType, PanoRuler
                 $line.style.transform = `rotate(${-deg}deg)`
 
                 $label.style.left = `${labelOffset}%`
-                $label.style.transform = `rotate(${Math.abs(deg) > 180 ? 180 : 0}deg)`
+                $label.style.transform = `rotate(${Math.abs(deg) > 90 ? 180 : 0}deg)`
             }
         }
     }

--- a/plugins/src/PanoRulerPlugin/Plugin.ts
+++ b/plugins/src/PanoRulerPlugin/Plugin.ts
@@ -442,7 +442,6 @@ export const PanoRulerPlugin: FivePlugin<PanoRulerPluginParameterType, PanoRuler
                 $line.style.transform = `rotate(${-deg}deg)`
 
                 $label.style.left = `${labelOffset}%`
-                $label.style.transform = `rotate(${Math.abs(deg) > 90 ? 180 : 0}deg)`
             }
         }
     }

--- a/plugins/src/PanoRulerPlugin/Plugin.ts
+++ b/plugins/src/PanoRulerPlugin/Plugin.ts
@@ -236,7 +236,7 @@ export const PanoRulerPlugin: FivePlugin<PanoRulerPluginParameterType, PanoRuler
 
         state.loaded = false
 
-        state.options = Object.assign({}, state.options, options || {})
+        state.options = { ...state.options, ...options || {}}
         if (five.model.loaded) {
             return _load(roomInfo, roomRules)
         } else {
@@ -350,8 +350,8 @@ export const PanoRulerPlugin: FivePlugin<PanoRulerPluginParameterType, PanoRuler
                 $element.style.display = 'none'
                 continue
             }
-
-            if (start.distanceTo(end) < 0.5) {
+            // 线小于0.3m隐藏
+            if (start.distanceTo(end) < 0.3) {
                 $element.style.display = 'none'
                 continue
             }
@@ -442,6 +442,7 @@ export const PanoRulerPlugin: FivePlugin<PanoRulerPluginParameterType, PanoRuler
                 $line.style.transform = `rotate(${-deg}deg)`
 
                 $label.style.left = `${labelOffset}%`
+                $label.style.transform = `rotate(${Math.abs(deg) > 180 ? 180 : 0}deg)`
             }
         }
     }


### PR DESCRIPTION
PanoRulerPlugin 修改标尺隐藏策略，由原来的线小于0.5m隐藏改为线长小于0.3m隐藏