### PR TITLE
修复 ModelRoomLabelPlugin 问题

### DIFF
--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.3
+- 1. fix: ModelRoomLabelPlugin 修复在 Five 模型切换动画过程中改变楼层，没有触发刷新的问题。
+- 2. fix: ModelRoomLabelPlugin 修复切换楼层时，没有触发立即刷新的问题。
+
 ## 2.0.2
 - 1. feat: FloorplanPlugin 支持动态修改房间面积展示和房间标尺展示
 - 2. feat: PanoRulerPlugin 支持动态修改距离展示

--- a/plugins/src/ModelRoomLabelPlugin/RoomLabelItems.svelte
+++ b/plugins/src/ModelRoomLabelPlugin/RoomLabelItems.svelte
@@ -10,24 +10,17 @@
 
   let containerWidth: number
   let containerHeight: number
-  let shownFloor: number | null = null
+  let shownFloor: number | null = five.model.shownFloor ?? null
   $: rendererSize = { x: containerWidth, y: containerHeight }
 
   $: {
-    // rendererSize 变化时，触发 reRender
-    roomLabels = getFormatedRoomLabels(rendererSize)
-  }
-
-  $: {
-    // shownFloor 变化时，更新 item visible
-    roomLabels = roomLabels.map((item) => {
-      const isLabelInFloor = shownFloor === null || item.floorIndex === shownFloor
-      const visible = isLabelInFloor ? item.visible : false
-      return {...item, visible}
-    })
+    // rendererSize 和 shownFloor 变化时，触发 reRender
+    roomLabels = getFormatedRoomLabels({ rendererSize, shownFloor })
   }
 
   function getLabelVisible(item: RoomLabel) {
+    const isLabelInFloor = shownFloor === null || item.floorIndex === shownFloor
+    if (!isLabelInFloor) return false
     const raycaster = new Raycaster()
     const cameraPosition = five.camera.position.clone()
     const position = new Vector3(item.position.x, item.position.y, item.position.z)
@@ -48,7 +41,11 @@
     return `translate(${xOffset}px, ${yOffset}px)`
   }
 
-  function getFormatedRoomLabels(rendererSize: { x: number; y: number }) {
+  function getFormatedRoomLabels(params: {
+    rendererSize: { x: number; y: number }
+    shownFloor: number
+  }) {
+    const { rendererSize, shownFloor } = params
     // 因为 item distance 需要重复计算，所以缓存一下
     const distanceMap = new Map<string, number>()
 
@@ -77,7 +74,7 @@
   }
 
   function onFiveCameraUpdate() {
-    roomLabels = getFormatedRoomLabels(rendererSize)
+    roomLabels = getFormatedRoomLabels({ rendererSize, shownFloor })
   }
 
   function onFiveModelShownFloorChange(floorIndex: null | number) {


### PR DESCRIPTION
* fix: ModelRoomLabelPlugin 修复在 Five 模型切换动画过程中改变楼层，没有触发刷新的问题。
* fix: ModelRoomLabelPlugin 修复切换楼层时，没有触发立即刷新的问题。